### PR TITLE
CAV-573: Internal Auth for cip-email-validation service

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For reference here are the details for running each of the services individually
 
 #### Validate
 
-    -XPOST -H "Content-type: application/json" -d '{
+    -XPOST -H "Content-type: application/json" -H "Authorization: fI2zfC5z-xuvDBT7riTHoOssnmqNRJ1IRnBixf8MThPepxTaRoi7pYaTZ9YKG3IP5DdshgpQ5" -d '{
 	    "email": "<email>"
     }' 'https://cip-email-validation.protected.mdtp/customer-insight-platform/email/validate'
 

--- a/app/uk/gov/hmrc/cipemailvalidation/controllers/ValidateController.scala
+++ b/app/uk/gov/hmrc/cipemailvalidation/controllers/ValidateController.scala
@@ -22,6 +22,7 @@ import play.api.mvc.{Action, ControllerComponents, Request, Result}
 import uk.gov.hmrc.cipemailvalidation.model.ErrorResponse.Codes.VALIDATION_ERROR
 import uk.gov.hmrc.cipemailvalidation.model.ErrorResponse.Message.INVALID_EMAIL
 import uk.gov.hmrc.cipemailvalidation.model.{Email, ErrorResponse}
+import uk.gov.hmrc.internalauth.client._
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.{Inject, Singleton}
@@ -29,10 +30,15 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 @Singleton()
-class ValidateController @Inject()(cc: ControllerComponents)
+class ValidateController @Inject()(cc: ControllerComponents, auth: BackendAuthComponents)
   extends BackendController(cc) with Logging {
 
-  def validate(): Action[JsValue] = Action(parse.json).async { implicit request =>
+  val permission = Predicate.Permission(Resource(
+    ResourceType("cip-email-validation"),
+    ResourceLocation("*")),
+    IAAction("*"))
+
+  def validate(): Action[JsValue] = auth.authorizedAction[Unit](permission).compose(Action(parse.json)).async { implicit request =>
     withJsonBody[Email] { _ => Future.successful(Ok(request.body)) }
   }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -39,6 +39,9 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 
+# Internal auth module
+play.modules.enabled += "uk.gov.hmrc.internalauth.client.modules.InternalAuthModule"
+
 # Json error handler
 play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler"
 
@@ -94,5 +97,10 @@ microservice {
       enabled = false
     }
   }
+  services {
+    internal-auth {
+      host = localhost
+      port = 6199
+    }
+  }
 }
-

--- a/it/uk/gov/hmrc/cipemailvalidation/ValidateIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/cipemailvalidation/ValidateIntegrationSpec.scala
@@ -20,10 +20,9 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
+import play.api.libs.ws.ahc.AhcCurlRequestLogger
 
 class ValidateIntegrationSpec
   extends AnyWordSpec
@@ -35,18 +34,16 @@ class ValidateIntegrationSpec
   private val wsClient = app.injector.instanceOf[WSClient]
   private val baseUrl = s"http://localhost:$port"
 
-  override def fakeApplication(): Application =
-    GuiceApplicationBuilder()
-      .configure("metrics.enabled" -> false)
-      .configure("auditing.enabled" -> false)
-      .build()
-
   "validate" should {
     "respond with 200 status with valid email address" in {
       val response =
         wsClient
           .url(s"$baseUrl/customer-insight-platform/email/validate")
-          .post(Json.parse {"""{"email": "test@test.com"}""".stripMargin})
+          .withHttpHeaders(("Authorization", "fake-token"))
+          .withRequestFilter(AhcCurlRequestLogger())
+          .post(Json.parse {
+            """{"email": "test@test.com"}""".stripMargin
+          })
           .futureValue
 
       response.status shouldBe 200
@@ -56,7 +53,11 @@ class ValidateIntegrationSpec
       val response =
         wsClient
           .url(s"$baseUrl/customer-insight-platform/email/validate")
-          .post(Json.parse {"""{"email": "invalid email"}""".stripMargin})
+          .withHttpHeaders(("Authorization", "fake-token"))
+          .withRequestFilter(AhcCurlRequestLogger())
+          .post(Json.parse {
+            """{"email": "invalid email"}""".stripMargin
+          })
           .futureValue
 
       response.status shouldBe 400

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,8 @@ object AppDependencies {
   val hmrcBootstrapVersion = "7.2.0"
 
   val compile = Seq(
-    "uk.gov.hmrc" %% "bootstrap-backend-play-28" % hmrcBootstrapVersion,
+    "uk.gov.hmrc" %% "bootstrap-backend-play-28"    % hmrcBootstrapVersion,
+    "uk.gov.hmrc" %% "internal-auth-client-play-28" % "1.2.0"
   )
 
   val test = Seq(

--- a/test/uk/gov/hmrc/cipemailvalidation/controllers/ValidateControllerSpec.scala
+++ b/test/uk/gov/hmrc/cipemailvalidation/controllers/ValidateControllerSpec.scala
@@ -16,37 +16,40 @@
 
 package uk.gov.hmrc.cipemailvalidation.controllers
 
+import org.mockito.IdiomaticMockito
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.libs.json.{Json, OWrites}
-import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
+import play.api.test.{FakeRequest, Helpers}
 import uk.gov.hmrc.cipemailvalidation.model.Email
+import uk.gov.hmrc.internalauth.client.Predicate.Permission
+import uk.gov.hmrc.internalauth.client._
+import uk.gov.hmrc.internalauth.client.test.{BackendAuthComponentsStub, StubBehaviour}
 
+import scala.concurrent.ExecutionContext.Implicits
+import scala.concurrent.Future
 import scala.util.Random
 
-class ValidateControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
-  private val fakeRequest = FakeRequest()
-  private lazy val controller = app.injector.instanceOf[ValidateController]
-  private implicit val writes: OWrites[Email] = Json.writes[Email]
-
-  "POST /" should {
-    "return 200 with valid email address" in {
+class ValidateControllerSpec extends AnyWordSpec
+  with Matchers
+  with IdiomaticMockito {
+  "validate" should {
+    "return 200 with valid email address" in new SetUp {
       val result = controller.validate()(
         fakeRequest.withBody(Json.toJson(Email("test@test.com"))))
       status(result) shouldBe OK
     }
 
-    "return 400 with email with no @" in {
+    "return 400 with email with no @" in new SetUp {
       val result = controller.validate()(
         fakeRequest.withBody(Json.toJson(Email("invalid.email"))))
       status(result) shouldBe BAD_REQUEST
-      (contentAsJson(result) \ "message" ).as[String] shouldBe "Enter a valid email"
+      (contentAsJson(result) \ "message").as[String] shouldBe "Enter a valid email"
     }
 
-    "return 400 with email address too long" in {
+    "return 400 with email address too long" in new SetUp {
       val local = s"${Random.alphanumeric.take(248).mkString}"
       val domain = "test"
       val topLevelDomain = "com"
@@ -54,29 +57,40 @@ class ValidateControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppP
       val result = controller.validate()(
         fakeRequest.withBody(Json.toJson(Email(email))))
       status(result) shouldBe BAD_REQUEST
-      (contentAsJson(result) \ "message" ).as[String] shouldBe "Enter a valid email"
+      (contentAsJson(result) \ "message").as[String] shouldBe "Enter a valid email"
     }
 
-    "return 400 with email address with spaces" in {
+    "return 400 with email address with spaces" in new SetUp {
       val result = controller.validate()(
         fakeRequest.withBody(Json.toJson(Email("invalid email"))))
       status(result) shouldBe BAD_REQUEST
-      (contentAsJson(result) \ "message" ).as[String] shouldBe "Enter a valid email"
+      (contentAsJson(result) \ "message").as[String] shouldBe "Enter a valid email"
     }
 
-    "return 400 with blank email" in {
+    "return 400 with blank email" in new SetUp {
       val result = controller.validate()(
         fakeRequest.withBody(Json.toJson(Email(""))))
       status(result) shouldBe BAD_REQUEST
-      (contentAsJson(result) \ "message" ).as[String] shouldBe "Enter a valid email"
+      (contentAsJson(result) \ "message").as[String] shouldBe "Enter a valid email"
     }
 
-    "return 400 with blank email with spaces" in {
+    "return 400 with blank email with spaces" in new SetUp {
       val result = controller.validate()(
         fakeRequest.withBody(Json.toJson(Email(" "))))
       status(result) shouldBe BAD_REQUEST
-      (contentAsJson(result) \ "message" ).as[String] shouldBe "Enter a valid email"
+      (contentAsJson(result) \ "message").as[String] shouldBe "Enter a valid email"
     }
   }
-}
 
+  trait SetUp {
+    protected val fakeRequest = FakeRequest().withHeaders("Authorization" -> "fake-token")
+    val expectedPredicate = {
+      Permission(Resource(ResourceType("cip-email-validation"), ResourceLocation("*")), IAAction("*"))
+    }
+    protected val mockStubBehaviour = mock[StubBehaviour]
+    mockStubBehaviour.stubAuth(Some(expectedPredicate), Retrieval.EmptyRetrieval).returns(Future.unit)
+    protected val backendAuthComponentsStub = BackendAuthComponentsStub(mockStubBehaviour)(Helpers.stubControllerComponents(), Implicits.global)
+    protected lazy val controller = new ValidateController(Helpers.stubControllerComponents(), backendAuthComponentsStub)
+    protected implicit val writes: OWrites[Email] = Json.writes[Email]
+  }
+}


### PR DESCRIPTION
 - added internal-auth to validate endpoint